### PR TITLE
Add wine search and filtering frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Dependencies
+frontend/node_modules/
+
+# Build output
+frontend/dist/
+
+# TypeScript incremental files
+frontend/*.tsbuildinfo
+
+# Environment files
+frontend/.env
+frontend/.env.*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ frontend/node_modules/
 
 # Build output
 frontend/dist/
+frontend/vite.config.js
+frontend/vite.config.d.ts
 
 # TypeScript incremental files
 frontend/*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# thestory
-This is the beginning of The Asplund Story
+# The Story – Vinguide
+
+Detta repo innehåller en enkel React/Vite-applikation för att söka och filtrera i Systembolagets produktdata. Projektet är tänkt att fungera tillsammans med containern `ghcr.io/c4illin/systembolaget-data` men har även reservdata så att gränssnittet går att testa direkt.
+
+## Kom igång
+
+1. Installera beroenden:
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. (Valfritt) starta API:t via Docker-compose-filen i projektets rot:
+   ```bash
+   docker compose up systembolaget-data
+   ```
+   API:t exponerar då produkter på `http://localhost:3000/products`.
+
+3. Starta utvecklingsservern:
+   ```bash
+   npm run dev
+   ```
+
+4. Öppna webbläsaren på adressen som Vite visar (standard `http://localhost:5173`).
+
+Applikationen försöker först hämta data från `VITE_API_URL` (standard `http://localhost:3000`). Om anropet misslyckas laddas `frontend/public/sample-data.json` som reservdata.
+
+## Konfiguration
+
+| Variabel        | Standard               | Beskrivning                                   |
+| --------------- | ---------------------- | --------------------------------------------- |
+| `VITE_API_URL`  | `http://localhost:3000` | Bas-URL till API:t med Systembolagets data.   |
+
+## Projektstruktur
+
+```
+frontend/
+  ├─ src/
+  │   ├─ App.tsx          # UI och filtreringslogik
+  │   ├─ main.tsx         # Inträde för React
+  │   └─ styles/          # Globala och komponentrelaterade stilar
+  ├─ public/
+  │   └─ sample-data.json # Reservdata för offline-testning
+  ├─ index.html
+  └─ vite.config.ts
+```
+
+## Nästa steg
+
+- Lägga till fler filter (t.ex. druvor, sockerhalt, årgång).
+- Implementera klient-side caching och paginering för stora datamängder.
+- Koppla på avancerad sök med textindexering i API:t.
+
+Lycka till med vidare utveckling!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # The Story – Vinguide
 
-Detta repo innehåller en enkel React/Vite-applikation för att söka och filtrera i Systembolagets produktdata. Projektet är tänkt att fungera tillsammans med containern `ghcr.io/c4illin/systembolaget-data` men har även reservdata så att gränssnittet går att testa direkt.
+Detta repo innehåller en enkel React/Vite-applikation för att söka och filtrera i Systembolagets produktdata. Projektet är tänkt att fungera tillsammans med containern `ghcr.io/c4illin/systembolaget-data` men har även reservdata så att gränssnittet går att testa direkt. Utöver grundfiltreringen innehåller appen nu:
+
+- **Drickfönster- och lagringsfilter** för att snabbt hitta viner som passar din tidsplan eller källarkapacitet.
+- **Wine-Searcher analys** som räknar fram värdeökning baserat på externa data och lyfter fram de mest intressanta flaskorna för investering.
 
 ## Kom igång
 
@@ -23,13 +26,13 @@ Detta repo innehåller en enkel React/Vite-applikation för att söka och filtre
 
 4. Öppna webbläsaren på adressen som Vite visar (standard `http://localhost:5173`).
 
-Applikationen försöker först hämta data från `VITE_API_URL` (standard `http://localhost:3000`). Om anropet misslyckas laddas `frontend/public/sample-data.json` som reservdata.
+Applikationen försöker först hämta data från `VITE_API_URL` (standard `http://localhost:3000`). Om anropet misslyckas laddas `frontend/public/sample-data.json` som reservdata. För värdeanalysen anropas `GET /value-insights?ids=...`; vid fel används `frontend/public/sample-value-insights.json`.
 
 ## Konfiguration
 
-| Variabel        | Standard               | Beskrivning                                   |
-| --------------- | ---------------------- | --------------------------------------------- |
-| `VITE_API_URL`  | `http://localhost:3000` | Bas-URL till API:t med Systembolagets data.   |
+| Variabel        | Standard               | Beskrivning                                                                 |
+| --------------- | ---------------------- | --------------------------------------------------------------------------- |
+| `VITE_API_URL`  | `http://localhost:3000` | Bas-URL till API:t med Systembolagets data och endpointen `/value-insights`. |
 
 ## Projektstruktur
 
@@ -40,15 +43,16 @@ frontend/
   │   ├─ main.tsx         # Inträde för React
   │   └─ styles/          # Globala och komponentrelaterade stilar
   ├─ public/
-  │   └─ sample-data.json # Reservdata för offline-testning
+  │   ├─ sample-data.json          # Reservdata för produkter
+  │   └─ sample-value-insights.json # Reservdata för Wine-Searcher-analys
   ├─ index.html
   └─ vite.config.ts
 ```
 
-## Nästa steg
+## Tips för vidareutveckling
 
-- Lägga till fler filter (t.ex. druvor, sockerhalt, årgång).
-- Implementera klient-side caching och paginering för stora datamängder.
-- Koppla på avancerad sök med textindexering i API:t.
+- Utöka API:t med fler datakällor (t.ex. auktioner eller sekundärmarknad) och mappa dem till Wine-Searcher-analysen.
+- Lägg till grafer över historisk prisutveckling per produkt.
+- Komplettera filtren med druvsammansättning, expertbetyg och koldioxidavtryck.
 
 Lycka till med vidare utveckling!

--- a/README.md
+++ b/README.md
@@ -30,9 +30,25 @@ Applikationen försöker först hämta data från `VITE_API_URL` (standard `http
 
 ## Konfiguration
 
-| Variabel        | Standard               | Beskrivning                                                                 |
-| --------------- | ---------------------- | --------------------------------------------------------------------------- |
-| `VITE_API_URL`  | `http://localhost:3000` | Bas-URL till API:t med Systembolagets data och endpointen `/value-insights`. |
+| Variabel                    | Standard                | Beskrivning                                                                                 |
+| --------------------------- | ----------------------- | ------------------------------------------------------------------------------------------- |
+| `VITE_API_URL`              | `http://localhost:3000` | Bas-URL till API:t med Systembolagets data och endpointen `/value-insights`.                |
+| `VITE_FIRECRAWL_API_KEY`    | –                       | API-nyckel för Firecrawl som används för att hämta sammanfattningar av Wine-Searcher-sidor. |
+| `VITE_FIRECRAWL_BASE_URL`   | `https://api.firecrawl.dev` | Valfri: ändra om du kör en egen Firecrawl-instans.                                          |
+| `VITE_FIRECRAWL_MAX_RESULTS` | `6`                     | Hur många unika länkar som hämtas samtidigt för sammanfattning.                             |
+
+### Firecrawl
+
+1. Skaffa en API-nyckel på [firecrawl.dev](https://firecrawl.dev/) och exportera den innan du startar bygget:
+   ```bash
+   export VITE_FIRECRAWL_API_KEY=sk_your_key
+   ```
+2. Bygg eller starta utvecklingsservern. Frontenden hämtar automatiskt upp till `VITE_FIRECRAWL_MAX_RESULTS`
+   Wine-Searcher-länkar från resultatslistan och presenterar en kort sammanfattning i varje kort.
+3. Om du själv hostar Firecrawl kan du peka `VITE_FIRECRAWL_BASE_URL` mot din instans (t.ex. `https://firecrawl.example.com`).
+
+> Tips: Utan API-nyckel visas en instruktion i varje kort som har en Wine-Searcher-länk så att testare vet hur
+> sammanfattningarna aktiveras.
 
 ## Projektstruktur
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vinguide – Sök och filtrera</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1699 @@
+{
+  "name": "thestory-wine-search",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thestory-wine-search",
+      "version": "0.0.1",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^24.5.2",
+        "@types/react": "^18.3.5",
+        "@types/react-dom": "^18.3.2",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
+      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.224",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
+      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "thestory-wine-search",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.1"
+  }
+}

--- a/frontend/public/sample-data.json
+++ b/frontend/public/sample-data.json
@@ -13,6 +13,9 @@
     "Organic": true,
     "Ethical": false,
     "SustainableChoice": true,
+    "DrinkFromYear": 2024,
+    "DrinkToYear": 2032,
+    "StoragePotential": "Lagringsbar upp till 8-10 år",
     "Taste": "Stramt och smakrikt med toner av körsbär, rosor och kryddor.",
     "Usage": "Nöt, vilt, lagrade ostar"
   },
@@ -30,6 +33,9 @@
     "Organic": false,
     "Ethical": false,
     "SustainableChoice": false,
+    "DrinkFromYear": 2023,
+    "DrinkToYear": 2025,
+    "StoragePotential": "Drick nu, begränsad lagringspotential",
     "Taste": "Friskt med toner av citrus och gröna äpplen.",
     "Usage": "Fisk och skaldjur"
   },
@@ -47,6 +53,9 @@
     "Organic": false,
     "Ethical": true,
     "SustainableChoice": true,
+    "DrinkFromYear": 2022,
+    "DrinkToYear": 2028,
+    "StoragePotential": "Kan lagras upp till 6 år",
     "Taste": "Elegant med inslag av brioche, äpplen och citrus.",
     "Usage": "Aperitif eller skaldjur"
   }

--- a/frontend/public/sample-data.json
+++ b/frontend/public/sample-data.json
@@ -1,0 +1,53 @@
+[
+  {
+    "ProductId": "1001",
+    "ProductNameBold": "Fontanafredda",
+    "ProductNameThin": "Barolo Serralunga d'Alba",
+    "Category": "Rött vin",
+    "Country": "Italien",
+    "OriginLevel1": "Piemonte",
+    "Grapes": ["Nebbiolo"],
+    "Price": 279,
+    "VolumeInMilliliter": 750,
+    "AlcoholPercent": "14",
+    "Organic": true,
+    "Ethical": false,
+    "SustainableChoice": true,
+    "Taste": "Stramt och smakrikt med toner av körsbär, rosor och kryddor.",
+    "Usage": "Nöt, vilt, lagrade ostar"
+  },
+  {
+    "ProductId": "2002",
+    "ProductNameBold": "Casal Garcia",
+    "ProductNameThin": "Vinho Verde",
+    "Category": "Vitt vin",
+    "Country": "Portugal",
+    "OriginLevel1": "Minho",
+    "Grapes": "Loureiro, Trajadura",
+    "Price": 89,
+    "VolumeInMilliliter": 750,
+    "AlcoholPercent": "9.5",
+    "Organic": false,
+    "Ethical": false,
+    "SustainableChoice": false,
+    "Taste": "Friskt med toner av citrus och gröna äpplen.",
+    "Usage": "Fisk och skaldjur"
+  },
+  {
+    "ProductId": "3003",
+    "ProductNameBold": "Champagne Palmer & Co",
+    "ProductNameThin": "Brut Réserve",
+    "Category": "Mousserande vin",
+    "Country": "Frankrike",
+    "OriginLevel1": "Champagne",
+    "Grapes": "Chardonnay, Pinot Noir, Pinot Meunier",
+    "Price": 399,
+    "VolumeInMilliliter": 750,
+    "AlcoholPercent": "12",
+    "Organic": false,
+    "Ethical": true,
+    "SustainableChoice": true,
+    "Taste": "Elegant med inslag av brioche, äpplen och citrus.",
+    "Usage": "Aperitif eller skaldjur"
+  }
+]

--- a/frontend/public/sample-value-insights.json
+++ b/frontend/public/sample-value-insights.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "1001",
+    "wineSearcherUrl": "https://www.wine-searcher.com/find/fontanafredda+barolo",
+    "averageMarketPrice": 420,
+    "benchmarkPrice": 510,
+    "twelveMonthChangePercent": 7.5,
+    "fiveYearChangePercent": 28.3,
+    "valueScore": "stark",
+    "analystNote": "Stabil efterfrågan på klassisk Barolo med stadig värdeökning över fem år."
+  },
+  {
+    "id": "2002",
+    "wineSearcherUrl": "https://www.wine-searcher.com/find/casal+garcia+vinho+verde",
+    "averageMarketPrice": 95,
+    "benchmarkPrice": 99,
+    "twelveMonthChangePercent": 1.2,
+    "fiveYearChangePercent": 4.1,
+    "valueScore": "neutral",
+    "analystNote": "Låg prisvariation – bäst som omedelbar konsumtion snarare än investering."
+  },
+  {
+    "id": "3003",
+    "wineSearcherUrl": "https://www.wine-searcher.com/find/palmer+brut+reserve",
+    "averageMarketPrice": 520,
+    "benchmarkPrice": 560,
+    "twelveMonthChangePercent": 9.8,
+    "fiveYearChangePercent": 34.6,
+    "valueScore": "exceptionell",
+    "analystNote": "Prestigechampagne med stark global efterfrågan och tydlig uppsida enligt Wine-Searcher."
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,684 @@
+import { useEffect, useMemo, useState } from 'react';
+import './styles/App.css';
+
+const FALLBACK_DATA_URL = '/sample-data.json';
+const API_BASE_URL = (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3000';
+
+export interface WineProduct {
+  id: string;
+  name: string;
+  category?: string;
+  subCategory?: string;
+  style?: string;
+  country?: string;
+  origin?: string;
+  grapes?: string[];
+  supplier?: string;
+  vintage?: string;
+  price: number;
+  volumeMl?: number;
+  alcoholPercent?: number;
+  sugarContent?: number;
+  organic?: boolean;
+  ethical?: boolean;
+  sustainableChoice?: boolean;
+  description?: string;
+  usage?: string;
+}
+
+interface FilterState {
+  search: string;
+  category: string;
+  country: string;
+  minPrice: string;
+  maxPrice: string;
+  minAlcohol: string;
+  maxAlcohol: string;
+  onlyOrganic: boolean;
+  onlyEthical: boolean;
+  onlySustainable: boolean;
+  sortBy: 'relevance' | 'price-asc' | 'price-desc' | 'alcohol-desc';
+}
+
+const DEFAULT_FILTERS: FilterState = {
+  search: '',
+  category: 'alla',
+  country: 'alla',
+  minPrice: '',
+  maxPrice: '',
+  minAlcohol: '',
+  maxAlcohol: '',
+  onlyOrganic: false,
+  onlyEthical: false,
+  onlySustainable: false,
+  sortBy: 'relevance'
+};
+
+const parseNumber = (value: unknown): number | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.replace(/[^0-9.,]/g, '').replace(',', '.');
+    const parsed = Number.parseFloat(normalised);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  return undefined;
+};
+
+const toArray = (value: unknown): string[] | undefined => {
+  if (!value) return undefined;
+  if (Array.isArray(value)) return value.filter(Boolean).map(String);
+  if (typeof value === 'string') {
+    return value
+      .split(/[,;\n]/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+};
+
+const normaliseProduct = (raw: Record<string, unknown>): WineProduct | null => {
+  const id =
+    (raw.id as string | undefined) ??
+    (raw.productId as string | undefined) ??
+    (raw.ProductId as string | undefined) ??
+    (raw.ProductNumber as string | undefined) ??
+    (typeof raw.ArticleNumber === 'number' ? String(raw.ArticleNumber) : (raw.ArticleNumber as string | undefined));
+
+  if (!id) {
+    return null;
+  }
+
+  const boldName =
+    (raw.name as string | undefined) ??
+    (raw.productNameBold as string | undefined) ??
+    (raw.ProductNameBold as string | undefined) ??
+    (raw.ProductName as string | undefined) ??
+    (raw.ProductTitle as string | undefined);
+  const thinName =
+    (raw.productNameThin as string | undefined) ??
+    (raw.ProductNameThin as string | undefined) ??
+    (raw.SubTitle as string | undefined);
+
+  const displayName = [boldName, thinName].filter(Boolean).join(' ').trim();
+
+  const category =
+    (raw.category as string | undefined) ??
+    (raw.Category as string | undefined) ??
+    (raw.CategoryLevel1 as string | undefined) ??
+    (raw.CategoryLevel as string | undefined);
+
+  const subCategory =
+    (raw.categoryLevel2 as string | undefined) ??
+    (raw.CategoryLevel2 as string | undefined) ??
+    (raw.CategoryLevel3 as string | undefined) ??
+    (raw.SubCategory as string | undefined);
+
+  const style =
+    (raw.categoryLevel3 as string | undefined) ??
+    (raw.CategoryLevel3 as string | undefined) ??
+    (raw.Style as string | undefined);
+
+  const country = (raw.country as string | undefined) ?? (raw.Country as string | undefined);
+  const origin =
+    (raw.origin as string | undefined) ??
+    (raw.OriginLevel1 as string | undefined) ??
+    (raw.Region as string | undefined) ??
+    (raw.District as string | undefined);
+
+  const grapes = toArray(raw.grapes ?? raw.Grapes ?? raw.GrapeSort ?? raw.GrapeSorts);
+
+  const supplier =
+    (raw.supplierName as string | undefined) ??
+    (raw.SupplierName as string | undefined) ??
+    (raw.ProducerName as string | undefined);
+
+  const price =
+    parseNumber(raw.price ?? raw.Price ?? raw.PriceIncludingVAT) ??
+    (raw.SystembolagetPrice && Array.isArray(raw.SystembolagetPrice)
+      ? parseNumber((raw.SystembolagetPrice as unknown[])[0])
+      : undefined) ??
+    0;
+
+  const volumeMl =
+    parseNumber(raw.volume ?? raw.Volume ?? raw.BottleVolume ?? raw.VolumeInMilliliter) ??
+    (parseNumber(raw.VolumeInCentiliter) !== undefined
+      ? (parseNumber(raw.VolumeInCentiliter) as number) * 10
+      : undefined);
+
+  const alcoholPercent =
+    parseNumber(raw.alcoholPercent ?? raw.AlcoholPercent ?? raw.AlcoholContent ?? raw.Alcohol) ?? undefined;
+
+  const sugarContent = parseNumber(raw.sugarContent ?? raw.SugarContent ?? raw.Sugar);
+
+  const organic = Boolean(raw.organic ?? raw.Organic ?? raw.IsOrganic);
+  const ethical = Boolean(raw.ethical ?? raw.Ethical ?? raw.EthicalLabel ?? raw.IsEthical);
+  const sustainableChoice = Boolean(raw.sustainableChoice ?? raw.IsSustainableChoice ?? raw.Sustainable);
+
+  const description =
+    (raw.taste as string | undefined) ??
+    (raw.Taste as string | undefined) ??
+    (raw.Description as string | undefined) ??
+    (raw.Character as string | undefined);
+
+  const usage = (raw.Usage as string | undefined) ?? (raw.UsageOfProduct as string | undefined);
+
+  const vintage = (raw.vintage as string | undefined) ?? (raw.Vintage as string | undefined);
+
+  return {
+    id,
+    name: displayName || id,
+    category: category ?? undefined,
+    subCategory: subCategory ?? undefined,
+    style: style ?? undefined,
+    country: country ?? undefined,
+    origin: origin ?? undefined,
+    grapes,
+    supplier,
+    vintage,
+    price,
+    volumeMl,
+    alcoholPercent,
+    sugarContent,
+    organic,
+    ethical,
+    sustainableChoice,
+    description,
+    usage
+  };
+};
+
+const buildQuery = (filters: FilterState): string => {
+  const params = new URLSearchParams();
+
+  if (filters.search.trim()) params.set('q', filters.search.trim());
+  if (filters.category !== 'alla') params.set('category', filters.category);
+  if (filters.country !== 'alla') params.set('country', filters.country);
+  if (filters.minPrice) params.set('minPrice', filters.minPrice);
+  if (filters.maxPrice) params.set('maxPrice', filters.maxPrice);
+  if (filters.minAlcohol) params.set('minAlcohol', filters.minAlcohol);
+  if (filters.maxAlcohol) params.set('maxAlcohol', filters.maxAlcohol);
+  if (filters.onlyOrganic) params.set('organic', 'true');
+  if (filters.onlyEthical) params.set('ethical', 'true');
+  if (filters.onlySustainable) params.set('sustainable', 'true');
+  if (filters.sortBy !== 'relevance') params.set('sort', filters.sortBy);
+
+  return params.toString();
+};
+
+const useWineProducts = (filters: FilterState) => {
+  const [products, setProducts] = useState<WineProduct[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchProducts = async () => {
+      setLoading(true);
+      setError(null);
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 20_000);
+
+      try {
+        const query = buildQuery(filters);
+        const url = `${API_BASE_URL.replace(/\/$/, '')}/products${query ? `?${query}` : ''}`;
+        const response = await fetch(url, {
+          headers: { Accept: 'application/json' },
+          signal: controller.signal
+        });
+
+        if (!response.ok) {
+          throw new Error(`Misslyckades att hämta data (${response.status})`);
+        }
+
+        const data = await response.json();
+        const rawList: Record<string, unknown>[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.products)
+            ? (data.products as Record<string, unknown>[])
+            : [];
+
+        const normalised = rawList.map(normaliseProduct).filter(Boolean) as WineProduct[];
+
+        if (!cancelled) {
+          setProducts(normalised);
+        }
+      } catch (fetchError) {
+        console.warn('API-förfrågan misslyckades, försöker reservdata', fetchError);
+        try {
+          const fallbackResponse = await fetch(FALLBACK_DATA_URL, {
+            headers: { Accept: 'application/json' }
+          });
+          if (!fallbackResponse.ok) {
+            throw new Error('Kunde inte läsa reservdata');
+          }
+          const fallbackData = (await fallbackResponse.json()) as Record<string, unknown>[];
+          const normalisedFallback = fallbackData.map(normaliseProduct).filter(Boolean) as WineProduct[];
+          if (!cancelled) {
+            setProducts(normalisedFallback);
+          }
+        } catch (fallbackError) {
+          if (!cancelled) {
+            setError(
+              fetchError instanceof Error
+                ? fetchError.message
+                : 'Det gick inte att hämta vininformation just nu.'
+            );
+            console.error('Reservdata misslyckades', fallbackError);
+          }
+        }
+      } finally {
+        clearTimeout(timeout);
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchProducts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filters]);
+
+  return { products, loading, error };
+};
+
+const formatPrice = (price: number) =>
+  new Intl.NumberFormat('sv-SE', { style: 'currency', currency: 'SEK', maximumFractionDigits: 0 }).format(price);
+
+const formatVolume = (volume?: number) => {
+  if (!volume) return 'okänd volym';
+  if (volume >= 1000) {
+    return `${(volume / 1000).toFixed(volume % 1000 === 0 ? 0 : 1)} l`;
+  }
+  return `${volume} ml`;
+};
+
+const formatAlcohol = (alcohol?: number) => {
+  if (alcohol === undefined) return 'okänd alkohol';
+  return `${alcohol.toFixed(1)}%`;
+};
+
+const FilterTag = ({ label, onRemove }: { label: string; onRemove?: () => void }) => (
+  <button className="filter-tag" type="button" onClick={onRemove} aria-label={`Ta bort filtret ${label}`}>
+    <span>{label}</span>
+    {onRemove && <span aria-hidden="true">×</span>}
+  </button>
+);
+
+const App = () => {
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const { products, loading, error } = useWineProducts(filters);
+
+  const activeFilters = useMemo(() => {
+    const tags: { key: keyof FilterState; label: string }[] = [];
+    if (filters.search) tags.push({ key: 'search', label: `Sök: "${filters.search}"` });
+    if (filters.category !== 'alla') tags.push({ key: 'category', label: filters.category });
+    if (filters.country !== 'alla') tags.push({ key: 'country', label: filters.country });
+    if (filters.minPrice) tags.push({ key: 'minPrice', label: `Min ${filters.minPrice} kr` });
+    if (filters.maxPrice) tags.push({ key: 'maxPrice', label: `Max ${filters.maxPrice} kr` });
+    if (filters.minAlcohol) tags.push({ key: 'minAlcohol', label: `Min ${filters.minAlcohol}%` });
+    if (filters.maxAlcohol) tags.push({ key: 'maxAlcohol', label: `Max ${filters.maxAlcohol}%` });
+    if (filters.onlyOrganic) tags.push({ key: 'onlyOrganic', label: 'Endast ekologiskt' });
+    if (filters.onlyEthical) tags.push({ key: 'onlyEthical', label: 'Endast etiskt' });
+    if (filters.onlySustainable) tags.push({ key: 'onlySustainable', label: 'Hållbart val' });
+    return tags;
+  }, [filters]);
+
+  const filteredProducts = useMemo(() => {
+    const list = [...products];
+
+    const matches = list.filter((product) => {
+      const text = filters.search.toLowerCase();
+      const haystack = [product.name, product.category, product.country, product.origin, product.supplier]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (text && !haystack.includes(text)) {
+        return false;
+      }
+
+      if (filters.category !== 'alla' && product.category !== filters.category) {
+        return false;
+      }
+
+      if (filters.country !== 'alla' && product.country !== filters.country) {
+        return false;
+      }
+
+      const price = product.price;
+      if (filters.minPrice && price < Number(filters.minPrice)) {
+        return false;
+      }
+      if (filters.maxPrice && price > Number(filters.maxPrice)) {
+        return false;
+      }
+
+      const alcohol = product.alcoholPercent ?? null;
+      if (filters.minAlcohol && (alcohol === null || alcohol < Number(filters.minAlcohol))) {
+        return false;
+      }
+      if (filters.maxAlcohol && (alcohol === null || alcohol > Number(filters.maxAlcohol))) {
+        return false;
+      }
+
+      if (filters.onlyOrganic && !product.organic) {
+        return false;
+      }
+
+      if (filters.onlyEthical && !product.ethical) {
+        return false;
+      }
+
+      if (filters.onlySustainable && !product.sustainableChoice) {
+        return false;
+      }
+
+      return true;
+    });
+
+    switch (filters.sortBy) {
+      case 'price-asc':
+        return matches.sort((a, b) => a.price - b.price);
+      case 'price-desc':
+        return matches.sort((a, b) => b.price - a.price);
+      case 'alcohol-desc':
+        return matches.sort((a, b) => (b.alcoholPercent ?? 0) - (a.alcoholPercent ?? 0));
+      default:
+        return matches;
+    }
+  }, [filters, products]);
+
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    products.forEach((product) => {
+      if (product.category) {
+        set.add(product.category);
+      }
+    });
+    return Array.from(set).sort();
+  }, [products]);
+
+  const countryOptions = useMemo(() => {
+    const set = new Set<string>();
+    products.forEach((product) => {
+      if (product.country) {
+        set.add(product.country);
+      }
+    });
+    return Array.from(set).sort();
+  }, [products]);
+
+  const averagePrice = useMemo(() => {
+    if (!filteredProducts.length) return 0;
+    const total = filteredProducts.reduce((sum, product) => sum + product.price, 0);
+    return Math.round(total / filteredProducts.length);
+  }, [filteredProducts]);
+
+  const clearFilters = () => setFilters(DEFAULT_FILTERS);
+
+  return (
+    <div className="page">
+      <header className="page__header">
+        <h1>Vinguide</h1>
+        <p>Sök och filtrera i Systembolagets datamängder.</p>
+      </header>
+
+      <section className="filters">
+        <div className="filters__group">
+          <label htmlFor="search">Sök</label>
+          <input
+            id="search"
+            type="search"
+            placeholder="Sök på namn, land, producent..."
+            value={filters.search}
+            onChange={(event) => setFilters((current) => ({ ...current, search: event.target.value }))}
+          />
+        </div>
+
+        <div className="filters__row">
+          <div className="filters__group">
+            <label htmlFor="category">Kategori</label>
+            <select
+              id="category"
+              value={filters.category}
+              onChange={(event) => setFilters((current) => ({ ...current, category: event.target.value }))}
+            >
+              <option value="alla">Alla kategorier</option>
+              {categoryOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="filters__group">
+            <label htmlFor="country">Land</label>
+            <select
+              id="country"
+              value={filters.country}
+              onChange={(event) => setFilters((current) => ({ ...current, country: event.target.value }))}
+            >
+              <option value="alla">Alla länder</option>
+              {countryOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="filters__group">
+            <label htmlFor="sortBy">Sortering</label>
+            <select
+              id="sortBy"
+              value={filters.sortBy}
+              onChange={(event) => setFilters((current) => ({ ...current, sortBy: event.target.value as FilterState['sortBy'] }))}
+            >
+              <option value="relevance">Relevans</option>
+              <option value="price-asc">Pris, lägst först</option>
+              <option value="price-desc">Pris, högst först</option>
+              <option value="alcohol-desc">Alkoholhalt, högst först</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="filters__row">
+          <div className="filters__group filters__group--inline">
+            <label htmlFor="minPrice">Prisintervall</label>
+            <div className="filters__inputs-inline">
+              <input
+                id="minPrice"
+                type="number"
+                min={0}
+                placeholder="Min"
+                value={filters.minPrice}
+                onChange={(event) => setFilters((current) => ({ ...current, minPrice: event.target.value }))}
+              />
+              <span className="filters__separator">–</span>
+              <input
+                id="maxPrice"
+                type="number"
+                min={0}
+                placeholder="Max"
+                value={filters.maxPrice}
+                onChange={(event) => setFilters((current) => ({ ...current, maxPrice: event.target.value }))}
+              />
+            </div>
+          </div>
+
+          <div className="filters__group filters__group--inline">
+            <label htmlFor="minAlcohol">Alkohol %</label>
+            <div className="filters__inputs-inline">
+              <input
+                id="minAlcohol"
+                type="number"
+                min={0}
+                step={0.1}
+                placeholder="Min"
+                value={filters.minAlcohol}
+                onChange={(event) => setFilters((current) => ({ ...current, minAlcohol: event.target.value }))}
+              />
+              <span className="filters__separator">–</span>
+              <input
+                id="maxAlcohol"
+                type="number"
+                min={0}
+                step={0.1}
+                placeholder="Max"
+                value={filters.maxAlcohol}
+                onChange={(event) => setFilters((current) => ({ ...current, maxAlcohol: event.target.value }))}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="filters__checkboxes">
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={filters.onlyOrganic}
+              onChange={(event) => setFilters((current) => ({ ...current, onlyOrganic: event.target.checked }))}
+            />
+            <span>Endast ekologiskt</span>
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={filters.onlyEthical}
+              onChange={(event) => setFilters((current) => ({ ...current, onlyEthical: event.target.checked }))}
+            />
+            <span>Endast etiskt märkta</span>
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={filters.onlySustainable}
+              onChange={(event) =>
+                setFilters((current) => ({ ...current, onlySustainable: event.target.checked }))
+              }
+            />
+            <span>Hållbart val</span>
+          </label>
+        </div>
+
+        <div className="filters__footer">
+          <div className="filters__tags" aria-live="polite">
+            {activeFilters.length > 0 ? (
+              activeFilters.map((item) => (
+                <FilterTag
+                  key={item.key}
+                  label={item.label}
+                  onRemove={() => setFilters((current) => ({ ...current, [item.key]: DEFAULT_FILTERS[item.key] }))}
+                />
+              ))
+            ) : (
+              <span>Inga aktiva filter</span>
+            )}
+          </div>
+          <button className="button button--ghost" type="button" onClick={clearFilters} disabled={activeFilters.length === 0}>
+            Rensa alla filter
+          </button>
+        </div>
+      </section>
+
+      <section className="results" aria-live="polite">
+        <header className="results__header">
+          <h2>Träffar</h2>
+          <div className="results__meta">
+            {loading ? 'Hämtar data...' : `${filteredProducts.length} av ${products.length} produkter`}
+            {filteredProducts.length > 0 && (
+              <span className="results__average">Snittpris: {formatPrice(averagePrice)}</span>
+            )}
+          </div>
+        </header>
+
+        {error && (
+          <div className="results__error" role="alert">
+            <strong>Något gick fel:</strong> {error}
+          </div>
+        )}
+
+        {!loading && filteredProducts.length === 0 && !error && (
+          <p className="results__empty">Inga produkter matchade dina filter. Justera och försök igen.</p>
+        )}
+
+        <ul className="results__grid">
+          {filteredProducts.map((product) => (
+            <li key={product.id} className="card">
+              <div className="card__header">
+                <h3>{product.name}</h3>
+                <span className="card__price">{formatPrice(product.price)}</span>
+              </div>
+              <dl className="card__details">
+                {product.category && (
+                  <div>
+                    <dt>Kategori</dt>
+                    <dd>{product.category}</dd>
+                  </div>
+                )}
+                {product.country && (
+                  <div>
+                    <dt>Ursprung</dt>
+                    <dd>
+                      {product.country}
+                      {product.origin ? ` – ${product.origin}` : ''}
+                    </dd>
+                  </div>
+                )}
+                {product.volumeMl && (
+                  <div>
+                    <dt>Volym</dt>
+                    <dd>{formatVolume(product.volumeMl)}</dd>
+                  </div>
+                )}
+                {product.alcoholPercent !== undefined && (
+                  <div>
+                    <dt>Alkoholhalt</dt>
+                    <dd>{formatAlcohol(product.alcoholPercent)}</dd>
+                  </div>
+                )}
+                {product.grapes && product.grapes.length > 0 && (
+                  <div>
+                    <dt>Druvor</dt>
+                    <dd>{product.grapes.join(', ')}</dd>
+                  </div>
+                )}
+                {product.supplier && (
+                  <div>
+                    <dt>Producent</dt>
+                    <dd>{product.supplier}</dd>
+                  </div>
+                )}
+              </dl>
+              {(product.organic || product.ethical || product.sustainableChoice) && (
+                <div className="card__badges">
+                  {product.organic && <span className="badge">Ekologisk</span>}
+                  {product.ethical && <span className="badge">Etisk</span>}
+                  {product.sustainableChoice && <span className="badge">Hållbart val</span>}
+                </div>
+              )}
+              {product.description && <p className="card__description">{product.description}</p>}
+              {product.usage && <p className="card__usage">Passar till: {product.usage}</p>}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,38 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import './styles/App.css';
 
 const FALLBACK_DATA_URL = '/sample-data.json';
 const FALLBACK_VALUE_INSIGHTS_URL = '/sample-value-insights.json';
 const API_BASE_URL = (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3000';
+const FIRECRAWL_API_KEY = ((import.meta.env.VITE_FIRECRAWL_API_KEY as string | undefined) ?? '').trim() || undefined;
+const FIRECRAWL_BASE_URL = (() => {
+  const raw = (import.meta.env.VITE_FIRECRAWL_BASE_URL as string | undefined)?.trim();
+  if (!raw) {
+    return 'https://api.firecrawl.dev';
+  }
+  return raw.replace(/\/$/, '');
+})();
+const FIRECRAWL_TARGET_LIMIT = (() => {
+  const raw = (import.meta.env.VITE_FIRECRAWL_MAX_RESULTS as string | undefined)?.trim();
+  if (!raw) {
+    return 6;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return 6;
+  }
+  return parsed;
+})();
+
+type FirecrawlStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface FirecrawlSummaryState {
+  status: FirecrawlStatus;
+  sourceUrl: string;
+  title?: string;
+  summary?: string;
+  error?: string;
+}
 
 export interface WineValueInsight {
   id: string;
@@ -172,6 +201,32 @@ const toArray = (value: unknown): string[] | undefined => {
       .filter(Boolean);
   }
   return undefined;
+};
+
+const markdownToPlainText = (value: string): string =>
+  value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/(?:^|\n)[-+*]\s+/g, ' ')
+    .replace(/[#>*_~]+/g, ' ')
+    .replace(/\r?\n+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const summariseFirecrawlContent = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const plain = markdownToPlainText(value);
+  if (!plain) {
+    return undefined;
+  }
+  if (plain.length <= 600) {
+    return plain;
+  }
+  return `${plain.slice(0, 600).trim()}…`;
 };
 
 const normaliseValueScore = (value: unknown): WineValueInsight['valueScore'] | undefined => {
@@ -682,6 +737,13 @@ const FilterTag = ({ label, onRemove }: { label: string; onRemove?: () => void }
 const App = () => {
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const { products, loading, error } = useWineProducts(filters);
+  const firecrawlEnabled = Boolean(FIRECRAWL_API_KEY);
+  const [firecrawlSummaries, setFirecrawlSummaries] = useState<Record<string, FirecrawlSummaryState>>({});
+  const firecrawlSummariesRef = useRef(firecrawlSummaries);
+
+  useEffect(() => {
+    firecrawlSummariesRef.current = firecrawlSummaries;
+  }, [firecrawlSummaries]);
 
   const activeFilters = useMemo(() => {
     const tags: { key: keyof FilterState; label: string }[] = [];
@@ -805,6 +867,111 @@ const App = () => {
         return matches;
     }
   }, [filters, products]);
+
+  const firecrawlTargets = useMemo(() => {
+    if (!firecrawlEnabled) {
+      return [] as string[];
+    }
+    const urls = filteredProducts
+      .map((product) => product.valueInsight?.wineSearcherUrl)
+      .filter((url): url is string => typeof url === 'string' && url.length > 0);
+    return Array.from(new Set(urls)).slice(0, FIRECRAWL_TARGET_LIMIT);
+  }, [filteredProducts, firecrawlEnabled]);
+
+  useEffect(() => {
+    if (!firecrawlEnabled || !FIRECRAWL_API_KEY) {
+      return;
+    }
+    if (!firecrawlTargets.length) {
+      return;
+    }
+
+    let isActive = true;
+
+    const fetchSummaries = async () => {
+      for (const url of firecrawlTargets) {
+        if (!isActive) {
+          break;
+        }
+
+        const existing = firecrawlSummariesRef.current[url];
+        if (existing && (existing.status === 'loading' || existing.status === 'ready')) {
+          continue;
+        }
+
+        setFirecrawlSummaries((prev) => ({
+          ...prev,
+          [url]: {
+            status: 'loading',
+            sourceUrl: url
+          }
+        }));
+
+        try {
+          const response = await fetch(`${FIRECRAWL_BASE_URL}/v1/scrape`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+              Authorization: `Bearer ${FIRECRAWL_API_KEY}`
+            },
+            body: JSON.stringify({
+              url,
+              formats: ['markdown', 'extract', 'text']
+            })
+          });
+
+          if (!response.ok) {
+            throw new Error(`Firecrawl svarade med status ${response.status}`);
+          }
+
+          const payload = await response.json();
+          const data = payload?.data ?? payload ?? {};
+          const content =
+            (typeof data?.markdown === 'string' && data.markdown) ||
+            (typeof data?.extract === 'string' && data.extract) ||
+            (typeof data?.text === 'string' && data.text) ||
+            (typeof data?.content === 'string' && data.content) ||
+            undefined;
+          const summary = summariseFirecrawlContent(content);
+          const title = typeof data?.title === 'string' ? data.title : undefined;
+
+          if (!isActive) {
+            return;
+          }
+
+          setFirecrawlSummaries((prev) => ({
+            ...prev,
+            [url]: {
+              status: 'ready',
+              sourceUrl: url,
+              title,
+              summary
+            }
+          }));
+        } catch (fetchError) {
+          if (!isActive) {
+            return;
+          }
+
+          setFirecrawlSummaries((prev) => ({
+            ...prev,
+            [url]: {
+              status: 'error',
+              sourceUrl: url,
+              error: fetchError instanceof Error ? fetchError.message : 'Okänt fel'
+            }
+          }));
+        }
+      }
+    };
+
+    fetchSummaries();
+
+    return () => {
+      isActive = false;
+    };
+  }, [firecrawlTargets, firecrawlEnabled]);
 
   const categoryOptions = useMemo(() => {
     const set = new Set<string>();
@@ -1168,6 +1335,10 @@ const App = () => {
           {filteredProducts.map((product) => {
             const storageInfo = formatStorageInfo(product.storagePotentialYears, product.storageNote);
             const valueScoreLabel = translateValueScore(product.valueInsight?.valueScore);
+            const firecrawlUrl = product.valueInsight?.wineSearcherUrl;
+            const firecrawlSummary = firecrawlUrl ? firecrawlSummaries[firecrawlUrl] : undefined;
+            const firecrawlScheduled = firecrawlUrl ? firecrawlTargets.includes(firecrawlUrl) : false;
+            const firecrawlHeading = firecrawlSummary?.title?.trim() || 'Firecrawl-insikt';
             return (
               <li key={product.id} className="card">
                 <div className="card__header">
@@ -1285,6 +1456,36 @@ const App = () => {
                     </dl>
                     {product.valueInsight.analystNote && (
                       <p className="card__analysis-note">{product.valueInsight.analystNote}</p>
+                    )}
+                    {product.valueInsight.wineSearcherUrl && (
+                      <div className="card__analysis-firecrawl">
+                        <h5>{firecrawlHeading}</h5>
+                        {!firecrawlEnabled && (
+                          <p className="card__analysis-firecrawl-note">
+                            Lägg till <code>VITE_FIRECRAWL_API_KEY</code> för att visa automatiska sammanfattningar.
+                          </p>
+                        )}
+                        {firecrawlEnabled && firecrawlScheduled && (!firecrawlSummary || firecrawlSummary.status === 'loading') && (
+                          <p className="card__analysis-firecrawl-status">Hämtar analys från Firecrawl…</p>
+                        )}
+                        {firecrawlEnabled && firecrawlSummary?.status === 'ready' && firecrawlSummary.summary && (
+                          <p className="card__analysis-firecrawl-summary">{firecrawlSummary.summary}</p>
+                        )}
+                        {firecrawlEnabled && firecrawlSummary?.status === 'ready' && !firecrawlSummary.summary && (
+                          <p className="card__analysis-firecrawl-note">
+                            Firecrawl kunde inte extrahera någon sammanfattning för denna länk.
+                          </p>
+                        )}
+                        {firecrawlEnabled && firecrawlSummary?.status === 'error' && (
+                          <p className="card__analysis-firecrawl-error">Firecrawl-fel: {firecrawlSummary.error}</p>
+                        )}
+                        {firecrawlEnabled && firecrawlUrl && !firecrawlScheduled && !firecrawlSummary && (
+                          <p className="card__analysis-firecrawl-note">
+                            Firecrawl köar sammanfattningar för de första {FIRECRAWL_TARGET_LIMIT} träffarna. Förfina filtren
+                            för att inkludera denna länk.
+                          </p>
+                        )}
+                      </div>
                     )}
                     {product.valueInsight.wineSearcherUrl && (
                       <a

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,19 @@ import { useEffect, useMemo, useState } from 'react';
 import './styles/App.css';
 
 const FALLBACK_DATA_URL = '/sample-data.json';
+const FALLBACK_VALUE_INSIGHTS_URL = '/sample-value-insights.json';
 const API_BASE_URL = (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3000';
+
+export interface WineValueInsight {
+  id: string;
+  wineSearcherUrl?: string;
+  averageMarketPrice?: number;
+  benchmarkPrice?: number;
+  twelveMonthChangePercent?: number;
+  fiveYearChangePercent?: number;
+  analystNote?: string;
+  valueScore?: 'exceptionell' | 'stark' | 'neutral' | 'svag';
+}
 
 export interface WineProduct {
   id: string;
@@ -24,6 +36,11 @@ export interface WineProduct {
   sustainableChoice?: boolean;
   description?: string;
   usage?: string;
+  drinkFromYear?: number;
+  drinkToYear?: number;
+  storagePotentialYears?: number;
+  storageNote?: string;
+  valueInsight?: WineValueInsight;
 }
 
 interface FilterState {
@@ -37,6 +54,10 @@ interface FilterState {
   onlyOrganic: boolean;
   onlyEthical: boolean;
   onlySustainable: boolean;
+  drinkWindowFrom: string;
+  drinkWindowTo: string;
+  minStorageYears: string;
+  maxStorageYears: string;
   sortBy: 'relevance' | 'price-asc' | 'price-desc' | 'alcohol-desc';
 }
 
@@ -51,6 +72,10 @@ const DEFAULT_FILTERS: FilterState = {
   onlyOrganic: false,
   onlyEthical: false,
   onlySustainable: false,
+  drinkWindowFrom: '',
+  drinkWindowTo: '',
+  minStorageYears: '',
+  maxStorageYears: '',
   sortBy: 'relevance'
 };
 
@@ -64,12 +89,77 @@ const parseNumber = (value: unknown): number | undefined => {
   }
 
   if (typeof value === 'string') {
-    const normalised = value.replace(/[^0-9.,]/g, '').replace(',', '.');
+    const normalised = value.replace(/[^0-9.,-]/g, '').replace(',', '.');
+    if (normalised.includes('-')) {
+      const parts = normalised.split('-').map((part) => Number.parseFloat(part));
+      const filtered = parts.filter((part) => !Number.isNaN(part));
+      if (filtered.length > 0) {
+        return filtered[filtered.length - 1];
+      }
+    }
     const parsed = Number.parseFloat(normalised);
     return Number.isNaN(parsed) ? undefined : parsed;
   }
 
   return undefined;
+};
+
+const parseYearRange = (value: unknown): { from?: number; to?: number } => {
+  const years: number[] = [];
+
+  if (typeof value === 'number' && value >= 1000 && value <= 9999) {
+    years.push(value);
+  } else if (typeof value === 'string') {
+    const matches = value.match(/\d{4}/g);
+    if (matches) {
+      matches.forEach((match) => {
+        const year = Number.parseInt(match, 10);
+        if (!Number.isNaN(year)) {
+          years.push(year);
+        }
+      });
+    }
+  } else if (Array.isArray(value)) {
+    value.forEach((item) => {
+      const { from, to } = parseYearRange(item);
+      if (from) years.push(from);
+      if (to) years.push(to);
+    });
+  }
+
+  if (years.length === 0) {
+    return {};
+  }
+
+  const sorted = [...new Set(years)].sort((a, b) => a - b);
+
+  return {
+    from: sorted[0],
+    to: sorted.length > 1 ? sorted[sorted.length - 1] : undefined
+  };
+};
+
+const parseStoragePotential = (value: unknown): { years?: number; note?: string } => {
+  if (value === null || value === undefined) {
+    return {};
+  }
+
+  if (typeof value === 'number') {
+    return { years: value };
+  }
+
+  if (typeof value === 'string') {
+    const numberMatch = value.match(/\d+/g);
+    if (numberMatch && numberMatch.length > 0) {
+      const years = Number.parseInt(numberMatch[numberMatch.length - 1] ?? '', 10);
+      if (!Number.isNaN(years)) {
+        return { years, note: value };
+      }
+    }
+    return { note: value };
+  }
+
+  return {};
 };
 
 const toArray = (value: unknown): string[] | undefined => {
@@ -82,6 +172,147 @@ const toArray = (value: unknown): string[] | undefined => {
       .filter(Boolean);
   }
   return undefined;
+};
+
+const normaliseValueScore = (value: unknown): WineValueInsight['valueScore'] | undefined => {
+  if (!value) return undefined;
+  const normalised = String(value).trim().toLowerCase();
+  switch (normalised) {
+    case 'exceptionell':
+    case 'exceptional':
+      return 'exceptionell';
+    case 'stark':
+    case 'strong':
+      return 'stark';
+    case 'neutral':
+      return 'neutral';
+    case 'svag':
+    case 'weak':
+      return 'svag';
+    default:
+      return undefined;
+  }
+};
+
+const normaliseValueInsight = (raw: Record<string, unknown>): WineValueInsight | null => {
+  const id =
+    (raw.id as string | undefined) ??
+    (raw.productId as string | undefined) ??
+    (raw.ProductId as string | undefined) ??
+    (raw.articleId as string | undefined) ??
+    (raw.ArticleId as string | undefined);
+
+  if (!id) {
+    return null;
+  }
+
+  const averageMarketPrice = parseNumber(
+    raw.averageMarketPrice ?? raw.AverageMarketPrice ?? raw.marketPrice ?? raw.MarketPrice ?? raw.Price
+  );
+  const benchmarkPrice = parseNumber(
+    raw.benchmarkPrice ?? raw.BenchmarkPrice ?? raw.globalAveragePrice ?? raw.GlobalAveragePrice
+  );
+  const twelveMonthChangePercent = parseNumber(
+    raw.twelveMonthChangePercent ?? raw.TwelveMonthChangePercent ?? raw['12MonthChange'] ?? raw.YoyChange
+  );
+  const fiveYearChangePercent = parseNumber(
+    raw.fiveYearChangePercent ?? raw.FiveYearChangePercent ?? raw['5YearChange'] ?? raw.FiveYearTrend
+  );
+
+  const analystNote =
+    (raw.analystNote as string | undefined) ??
+    (raw.AnalystNote as string | undefined) ??
+    (raw.summary as string | undefined) ??
+    (raw.Summary as string | undefined) ??
+    (raw.Comment as string | undefined);
+
+  const wineSearcherUrl =
+    (raw.wineSearcherUrl as string | undefined) ??
+    (raw.WineSearcherUrl as string | undefined) ??
+    (raw.url as string | undefined) ??
+    (raw.Url as string | undefined);
+
+  const valueScore = normaliseValueScore(raw.valueScore ?? raw.ValueScore ?? raw.rating ?? raw.Rating);
+
+  return {
+    id,
+    wineSearcherUrl,
+    averageMarketPrice: averageMarketPrice ?? undefined,
+    benchmarkPrice: benchmarkPrice ?? undefined,
+    twelveMonthChangePercent: twelveMonthChangePercent ?? undefined,
+    fiveYearChangePercent: fiveYearChangePercent ?? undefined,
+    analystNote,
+    valueScore
+  };
+};
+
+const fetchValueInsights = async (productIds: string[]): Promise<Record<string, WineValueInsight>> => {
+  if (!productIds.length) {
+    return {};
+  }
+
+  const uniqueIds = Array.from(new Set(productIds));
+
+  const extract = (data: unknown): Record<string, WineValueInsight> => {
+    const rawList: Record<string, unknown>[] = Array.isArray(data)
+      ? data
+      : Array.isArray((data as { insights?: unknown[] } | undefined)?.insights)
+        ? (((data as { insights?: unknown[] }).insights ?? []) as Record<string, unknown>[])
+        : [];
+
+    return rawList.reduce<Record<string, WineValueInsight>>((accumulator, item) => {
+      const insight = normaliseValueInsight(item);
+      if (insight) {
+        accumulator[insight.id] = insight;
+      }
+      return accumulator;
+    }, {});
+  };
+
+  try {
+    const params = new URLSearchParams();
+    params.set('ids', uniqueIds.join(','));
+    const url = `${API_BASE_URL.replace(/\/$/, '')}/value-insights?${params.toString()}`;
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) {
+      throw new Error(`Misslyckades att hämta värdeinsikter (${response.status})`);
+    }
+    const data = await response.json();
+    return extract(data);
+  } catch (apiError) {
+    console.warn('Värdeinsikter via API misslyckades, använder reservdata', apiError);
+    const fallbackResponse = await fetch(FALLBACK_VALUE_INSIGHTS_URL, {
+      headers: { Accept: 'application/json' }
+    });
+    if (!fallbackResponse.ok) {
+      throw new Error('Kunde inte läsa reservinsikter');
+    }
+    const fallbackData = await fallbackResponse.json();
+    return extract(fallbackData);
+  }
+};
+
+const mergeWithValueInsights = async (products: WineProduct[]): Promise<WineProduct[]> => {
+  if (!products.length) {
+    return products;
+  }
+
+  try {
+    const insights = await fetchValueInsights(products.map((product) => product.id));
+    if (!Object.keys(insights).length) {
+      return products;
+    }
+
+    return products.map((product) => ({
+      ...product,
+      valueInsight: insights[product.id]
+    }));
+  } catch (error) {
+    console.warn('Kunde inte koppla värdeinsikter', error);
+    return products;
+  }
 };
 
 const normaliseProduct = (raw: Record<string, unknown>): WineProduct | null => {
@@ -172,6 +403,65 @@ const normaliseProduct = (raw: Record<string, unknown>): WineProduct | null => {
 
   const vintage = (raw.vintage as string | undefined) ?? (raw.Vintage as string | undefined);
 
+  const drinkWindowSources = [
+    raw.drinkWindow,
+    raw.DrinkWindow,
+    raw.drinkRange,
+    raw.DrinkRange,
+    raw.drinkability,
+    raw.Drinkability,
+    raw.drinkYears,
+    raw.DrinkYears,
+    raw.drinkDates,
+    raw.DrinkDates,
+    raw.drinkFromYear,
+    raw.drinkToYear,
+    raw.DrinkFromYear,
+    raw.DrinkToYear,
+    raw.BestBefore,
+    raw.BestAfter,
+    raw.ReadyToDrink,
+    raw.ReadyToDrinkYear
+  ].filter((item) => item !== undefined && item !== null);
+
+  const { from: drinkFromYear, to: drinkToYear } = parseYearRange(
+    drinkWindowSources.length === 0 ? undefined : drinkWindowSources.length === 1 ? drinkWindowSources[0] : drinkWindowSources
+  );
+
+  const storageRaw =
+    raw.storagePotential ??
+    raw.StoragePotential ??
+    raw.storage ??
+    raw.Storage ??
+    raw.storageRecommendation ??
+    raw.StorageRecommendation ??
+    raw.storageNote ??
+    raw.StorageNote ??
+    raw.AgingPotential ??
+    raw.CellarPotential ??
+    raw.CellaringPotential ??
+    raw.Maturity ??
+    raw.StorageComment;
+
+  const parsedStorage = parseStoragePotential(storageRaw);
+
+  const storagePotentialYears =
+    parsedStorage.years ??
+    parseNumber(
+      raw.storageYears ??
+        raw.StorageYears ??
+        raw.storageTime ??
+        raw.StorageTime ??
+        raw.maximumStorage ??
+        raw.MaximumStorage ??
+        raw.MaxStorageYears
+    );
+
+  const storageNote =
+    parsedStorage.note ??
+    (typeof storageRaw === 'string' ? storageRaw : undefined) ??
+    (raw.StorageComment as string | undefined);
+
   return {
     id,
     name: displayName || id,
@@ -191,7 +481,11 @@ const normaliseProduct = (raw: Record<string, unknown>): WineProduct | null => {
     ethical,
     sustainableChoice,
     description,
-    usage
+    usage,
+    drinkFromYear,
+    drinkToYear,
+    storagePotentialYears: storagePotentialYears ?? undefined,
+    storageNote
   };
 };
 
@@ -208,6 +502,10 @@ const buildQuery = (filters: FilterState): string => {
   if (filters.onlyOrganic) params.set('organic', 'true');
   if (filters.onlyEthical) params.set('ethical', 'true');
   if (filters.onlySustainable) params.set('sustainable', 'true');
+  if (filters.drinkWindowFrom) params.set('drinkFrom', filters.drinkWindowFrom);
+  if (filters.drinkWindowTo) params.set('drinkTo', filters.drinkWindowTo);
+  if (filters.minStorageYears) params.set('minStorageYears', filters.minStorageYears);
+  if (filters.maxStorageYears) params.set('maxStorageYears', filters.maxStorageYears);
   if (filters.sortBy !== 'relevance') params.set('sort', filters.sortBy);
 
   return params.toString();
@@ -248,9 +546,13 @@ const useWineProducts = (filters: FilterState) => {
             : [];
 
         const normalised = rawList.map(normaliseProduct).filter(Boolean) as WineProduct[];
+        let enriched = normalised;
+        if (!cancelled) {
+          enriched = await mergeWithValueInsights(normalised);
+        }
 
         if (!cancelled) {
-          setProducts(normalised);
+          setProducts(enriched);
         }
       } catch (fetchError) {
         console.warn('API-förfrågan misslyckades, försöker reservdata', fetchError);
@@ -263,8 +565,12 @@ const useWineProducts = (filters: FilterState) => {
           }
           const fallbackData = (await fallbackResponse.json()) as Record<string, unknown>[];
           const normalisedFallback = fallbackData.map(normaliseProduct).filter(Boolean) as WineProduct[];
+          let enrichedFallback = normalisedFallback;
           if (!cancelled) {
-            setProducts(normalisedFallback);
+            enrichedFallback = await mergeWithValueInsights(normalisedFallback);
+          }
+          if (!cancelled) {
+            setProducts(enrichedFallback);
           }
         } catch (fallbackError) {
           if (!cancelled) {
@@ -310,6 +616,62 @@ const formatAlcohol = (alcohol?: number) => {
   return `${alcohol.toFixed(1)}%`;
 };
 
+const formatDrinkWindow = (from?: number, to?: number) => {
+  if (from && to) {
+    return `${from}–${to}`;
+  }
+  if (from) {
+    return `från ${from}`;
+  }
+  if (to) {
+    return `till ${to}`;
+  }
+  return 'uppgift saknas';
+};
+
+const formatStorageInfo = (years?: number, note?: string) => {
+  const parts: string[] = [];
+  if (years !== undefined) {
+    parts.push(`upp till ${years} år`);
+  }
+  if (note) {
+    const trimmed = note.trim();
+    if (trimmed) {
+      if (parts.length > 0 && trimmed.toLowerCase().startsWith('upp till')) {
+        return trimmed;
+      }
+      parts.push(trimmed);
+    }
+  }
+  if (!parts.length) {
+    return undefined;
+  }
+  return parts
+    .map((fragment, index) => (index === 0 ? fragment.charAt(0).toUpperCase() + fragment.slice(1) : fragment))
+    .join('. ');
+};
+
+const formatPercentChange = (value: number) => {
+  const precision = Math.abs(value) >= 10 ? 0 : 1;
+  const formatted = value.toFixed(precision);
+  return `${value > 0 ? '+' : ''}${formatted}%`;
+};
+
+const translateValueScore = (score?: WineValueInsight['valueScore']) => {
+  switch (score) {
+    case 'exceptionell':
+      return 'Exceptionell potential';
+    case 'stark':
+      return 'Stark potential';
+    case 'neutral':
+      return 'Neutral utveckling';
+    case 'svag':
+      return 'Svag utveckling';
+    default:
+      return undefined;
+  }
+};
+
 const FilterTag = ({ label, onRemove }: { label: string; onRemove?: () => void }) => (
   <button className="filter-tag" type="button" onClick={onRemove} aria-label={`Ta bort filtret ${label}`}>
     <span>{label}</span>
@@ -333,6 +695,10 @@ const App = () => {
     if (filters.onlyOrganic) tags.push({ key: 'onlyOrganic', label: 'Endast ekologiskt' });
     if (filters.onlyEthical) tags.push({ key: 'onlyEthical', label: 'Endast etiskt' });
     if (filters.onlySustainable) tags.push({ key: 'onlySustainable', label: 'Hållbart val' });
+    if (filters.drinkWindowFrom) tags.push({ key: 'drinkWindowFrom', label: `Drickfönster från ${filters.drinkWindowFrom}` });
+    if (filters.drinkWindowTo) tags.push({ key: 'drinkWindowTo', label: `Drickfönster till ${filters.drinkWindowTo}` });
+    if (filters.minStorageYears) tags.push({ key: 'minStorageYears', label: `Lagring minst ${filters.minStorageYears} år` });
+    if (filters.maxStorageYears) tags.push({ key: 'maxStorageYears', label: `Lagring max ${filters.maxStorageYears} år` });
     return tags;
   }, [filters]);
 
@@ -386,6 +752,45 @@ const App = () => {
         return false;
       }
 
+      const drinkFrom = product.drinkFromYear ?? product.drinkToYear;
+      const drinkTo = product.drinkToYear ?? product.drinkFromYear;
+
+      if (filters.drinkWindowFrom) {
+        const desiredFrom = Number(filters.drinkWindowFrom);
+        if (!Number.isNaN(desiredFrom)) {
+          if (drinkTo === undefined || drinkTo < desiredFrom) {
+            return false;
+          }
+        }
+      }
+
+      if (filters.drinkWindowTo) {
+        const desiredTo = Number(filters.drinkWindowTo);
+        if (!Number.isNaN(desiredTo)) {
+          if (drinkFrom === undefined || drinkFrom > desiredTo) {
+            return false;
+          }
+        }
+      }
+
+      if (filters.minStorageYears) {
+        const minStorage = Number(filters.minStorageYears);
+        if (!Number.isNaN(minStorage)) {
+          if (product.storagePotentialYears === undefined || product.storagePotentialYears < minStorage) {
+            return false;
+          }
+        }
+      }
+
+      if (filters.maxStorageYears) {
+        const maxStorage = Number(filters.maxStorageYears);
+        if (!Number.isNaN(maxStorage)) {
+          if (product.storagePotentialYears === undefined || product.storagePotentialYears > maxStorage) {
+            return false;
+          }
+        }
+      }
+
       return true;
     });
 
@@ -425,6 +830,57 @@ const App = () => {
     if (!filteredProducts.length) return 0;
     const total = filteredProducts.reduce((sum, product) => sum + product.price, 0);
     return Math.round(total / filteredProducts.length);
+  }, [filteredProducts]);
+
+  const valueSummary = useMemo(() => {
+    const withInsights = filteredProducts.filter((product) => product.valueInsight);
+    if (!withInsights.length) {
+      return null;
+    }
+
+    const collectValues = (selector: (product: WineProduct) => number | undefined) =>
+      withInsights
+        .map(selector)
+        .filter((value): value is number => typeof value === 'number' && !Number.isNaN(value));
+
+    const average = (values: number[]) =>
+      values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : undefined;
+
+    const twelveMonthValues = collectValues((product) => product.valueInsight?.twelveMonthChangePercent);
+    const fiveYearValues = collectValues((product) => product.valueInsight?.fiveYearChangePercent);
+
+    const bestTwelveMonth = withInsights.reduce<
+      { product: WineProduct; change: number } | undefined
+    >((best, product) => {
+      const change = product.valueInsight?.twelveMonthChangePercent;
+      if (typeof change !== 'number' || Number.isNaN(change)) {
+        return best;
+      }
+      if (!best || change > best.change) {
+        return { product, change };
+      }
+      return best;
+    }, undefined);
+
+    const bestFiveYear = withInsights.reduce<
+      { product: WineProduct; change: number } | undefined
+    >((best, product) => {
+      const change = product.valueInsight?.fiveYearChangePercent;
+      if (typeof change !== 'number' || Number.isNaN(change)) {
+        return best;
+      }
+      if (!best || change > best.change) {
+        return { product, change };
+      }
+      return best;
+    }, undefined);
+
+    return {
+      avgTwelveMonth: average(twelveMonthValues),
+      avgFiveYear: average(fiveYearValues),
+      bestTwelveMonth,
+      bestFiveYear
+    };
   }, [filteredProducts]);
 
   const clearFilters = () => setFilters(DEFAULT_FILTERS);
@@ -546,6 +1002,62 @@ const App = () => {
           </div>
         </div>
 
+        <div className="filters__row">
+          <div className="filters__group filters__group--inline">
+            <label htmlFor="drinkWindowFrom">Drickfönster (år)</label>
+            <div className="filters__inputs-inline">
+              <input
+                id="drinkWindowFrom"
+                type="number"
+                min={1900}
+                max={2100}
+                placeholder="Från"
+                value={filters.drinkWindowFrom}
+                onChange={(event) =>
+                  setFilters((current) => ({ ...current, drinkWindowFrom: event.target.value }))
+                }
+              />
+              <span className="filters__separator">–</span>
+              <input
+                id="drinkWindowTo"
+                type="number"
+                min={1900}
+                max={2100}
+                placeholder="Till"
+                value={filters.drinkWindowTo}
+                onChange={(event) => setFilters((current) => ({ ...current, drinkWindowTo: event.target.value }))}
+              />
+            </div>
+          </div>
+
+          <div className="filters__group filters__group--inline">
+            <label htmlFor="minStorageYears">Lagringspotential (år)</label>
+            <div className="filters__inputs-inline">
+              <input
+                id="minStorageYears"
+                type="number"
+                min={0}
+                placeholder="Min"
+                value={filters.minStorageYears}
+                onChange={(event) =>
+                  setFilters((current) => ({ ...current, minStorageYears: event.target.value }))
+                }
+              />
+              <span className="filters__separator">–</span>
+              <input
+                id="maxStorageYears"
+                type="number"
+                min={0}
+                placeholder="Max"
+                value={filters.maxStorageYears}
+                onChange={(event) =>
+                  setFilters((current) => ({ ...current, maxStorageYears: event.target.value }))
+                }
+              />
+            </div>
+          </div>
+        </div>
+
         <div className="filters__checkboxes">
           <label className="checkbox">
             <input
@@ -606,6 +1118,42 @@ const App = () => {
           </div>
         </header>
 
+        {valueSummary && (
+          <aside className="results__insights" aria-live="polite">
+            <h3>Wine-Searcher analys</h3>
+            <dl className="results__insights-stats">
+              {valueSummary.avgTwelveMonth !== undefined && (
+                <div>
+                  <dt>Snitt 12 mån</dt>
+                  <dd>{formatPercentChange(valueSummary.avgTwelveMonth)}</dd>
+                </div>
+              )}
+              {valueSummary.avgFiveYear !== undefined && (
+                <div>
+                  <dt>Snitt 5 år</dt>
+                  <dd>{formatPercentChange(valueSummary.avgFiveYear)}</dd>
+                </div>
+              )}
+            </dl>
+            {(valueSummary.bestTwelveMonth || valueSummary.bestFiveYear) && (
+              <ul className="results__insights-leaders">
+                {valueSummary.bestTwelveMonth && (
+                  <li>
+                    Bäst 12 månader: <strong>{valueSummary.bestTwelveMonth.product.name}</strong>{' '}
+                    ({formatPercentChange(valueSummary.bestTwelveMonth.change)})
+                  </li>
+                )}
+                {valueSummary.bestFiveYear && (
+                  <li>
+                    Bäst 5 år: <strong>{valueSummary.bestFiveYear.product.name}</strong>{' '}
+                    ({formatPercentChange(valueSummary.bestFiveYear.change)})
+                  </li>
+                )}
+              </ul>
+            )}
+          </aside>
+        )}
+
         {error && (
           <div className="results__error" role="alert">
             <strong>Något gick fel:</strong> {error}
@@ -617,64 +1165,143 @@ const App = () => {
         )}
 
         <ul className="results__grid">
-          {filteredProducts.map((product) => (
-            <li key={product.id} className="card">
-              <div className="card__header">
-                <h3>{product.name}</h3>
-                <span className="card__price">{formatPrice(product.price)}</span>
-              </div>
-              <dl className="card__details">
-                {product.category && (
-                  <div>
-                    <dt>Kategori</dt>
-                    <dd>{product.category}</dd>
-                  </div>
-                )}
-                {product.country && (
-                  <div>
-                    <dt>Ursprung</dt>
-                    <dd>
-                      {product.country}
-                      {product.origin ? ` – ${product.origin}` : ''}
-                    </dd>
-                  </div>
-                )}
-                {product.volumeMl && (
-                  <div>
-                    <dt>Volym</dt>
-                    <dd>{formatVolume(product.volumeMl)}</dd>
-                  </div>
-                )}
-                {product.alcoholPercent !== undefined && (
-                  <div>
-                    <dt>Alkoholhalt</dt>
-                    <dd>{formatAlcohol(product.alcoholPercent)}</dd>
-                  </div>
-                )}
-                {product.grapes && product.grapes.length > 0 && (
-                  <div>
-                    <dt>Druvor</dt>
-                    <dd>{product.grapes.join(', ')}</dd>
-                  </div>
-                )}
-                {product.supplier && (
-                  <div>
-                    <dt>Producent</dt>
-                    <dd>{product.supplier}</dd>
-                  </div>
-                )}
-              </dl>
-              {(product.organic || product.ethical || product.sustainableChoice) && (
-                <div className="card__badges">
-                  {product.organic && <span className="badge">Ekologisk</span>}
-                  {product.ethical && <span className="badge">Etisk</span>}
-                  {product.sustainableChoice && <span className="badge">Hållbart val</span>}
+          {filteredProducts.map((product) => {
+            const storageInfo = formatStorageInfo(product.storagePotentialYears, product.storageNote);
+            const valueScoreLabel = translateValueScore(product.valueInsight?.valueScore);
+            return (
+              <li key={product.id} className="card">
+                <div className="card__header">
+                  <h3>{product.name}</h3>
+                  <span className="card__price">{formatPrice(product.price)}</span>
                 </div>
-              )}
-              {product.description && <p className="card__description">{product.description}</p>}
-              {product.usage && <p className="card__usage">Passar till: {product.usage}</p>}
-            </li>
-          ))}
+                <dl className="card__details">
+                  {product.category && (
+                    <div>
+                      <dt>Kategori</dt>
+                      <dd>{product.category}</dd>
+                    </div>
+                  )}
+                  {product.country && (
+                    <div>
+                      <dt>Ursprung</dt>
+                      <dd>
+                        {product.country}
+                        {product.origin ? ` – ${product.origin}` : ''}
+                      </dd>
+                    </div>
+                  )}
+                  {product.vintage && (
+                    <div>
+                      <dt>Årgång</dt>
+                      <dd>{product.vintage}</dd>
+                    </div>
+                  )}
+                  {(product.drinkFromYear || product.drinkToYear) && (
+                    <div>
+                      <dt>Drickfönster</dt>
+                      <dd>{formatDrinkWindow(product.drinkFromYear, product.drinkToYear)}</dd>
+                    </div>
+                  )}
+                  {storageInfo && (
+                    <div>
+                      <dt>Lagring</dt>
+                      <dd>{storageInfo}</dd>
+                    </div>
+                  )}
+                  {product.volumeMl && (
+                    <div>
+                      <dt>Volym</dt>
+                      <dd>{formatVolume(product.volumeMl)}</dd>
+                    </div>
+                  )}
+                  {product.alcoholPercent !== undefined && (
+                    <div>
+                      <dt>Alkoholhalt</dt>
+                      <dd>{formatAlcohol(product.alcoholPercent)}</dd>
+                    </div>
+                  )}
+                  {product.grapes && product.grapes.length > 0 && (
+                    <div>
+                      <dt>Druvor</dt>
+                      <dd>{product.grapes.join(', ')}</dd>
+                    </div>
+                  )}
+                  {product.supplier && (
+                    <div>
+                      <dt>Producent</dt>
+                      <dd>{product.supplier}</dd>
+                    </div>
+                  )}
+                </dl>
+                {(product.organic || product.ethical || product.sustainableChoice) && (
+                  <div className="card__badges">
+                    {product.organic && <span className="badge">Ekologisk</span>}
+                    {product.ethical && <span className="badge">Etisk</span>}
+                    {product.sustainableChoice && <span className="badge">Hållbart val</span>}
+                  </div>
+                )}
+                {product.description && <p className="card__description">{product.description}</p>}
+                {product.valueInsight && (
+                  <div className="card__analysis">
+                    <div className="card__analysis-header">
+                      <h4>Wine-Searcher</h4>
+                      {valueScoreLabel && (
+                        <span
+                          className={`badge badge--value ${
+                            product.valueInsight.valueScore
+                              ? `badge--value-${product.valueInsight.valueScore}`
+                              : ''
+                          }`.trim()}
+                        >
+                          {valueScoreLabel}
+                        </span>
+                      )}
+                    </div>
+                    <dl>
+                      {product.valueInsight.twelveMonthChangePercent !== undefined && (
+                        <div>
+                          <dt>12 mån värde</dt>
+                          <dd>{formatPercentChange(product.valueInsight.twelveMonthChangePercent)}</dd>
+                        </div>
+                      )}
+                      {product.valueInsight.fiveYearChangePercent !== undefined && (
+                        <div>
+                          <dt>5 år värde</dt>
+                          <dd>{formatPercentChange(product.valueInsight.fiveYearChangePercent)}</dd>
+                        </div>
+                      )}
+                      {product.valueInsight.averageMarketPrice !== undefined && (
+                        <div>
+                          <dt>Marknadspris</dt>
+                          <dd>{formatPrice(product.valueInsight.averageMarketPrice)}</dd>
+                        </div>
+                      )}
+                      {product.valueInsight.benchmarkPrice !== undefined && (
+                        <div>
+                          <dt>Benchmark</dt>
+                          <dd>{formatPrice(product.valueInsight.benchmarkPrice)}</dd>
+                        </div>
+                      )}
+                    </dl>
+                    {product.valueInsight.analystNote && (
+                      <p className="card__analysis-note">{product.valueInsight.analystNote}</p>
+                    )}
+                    {product.valueInsight.wineSearcherUrl && (
+                      <a
+                        className="card__analysis-link"
+                        href={product.valueInsight.wineSearcherUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Se detaljer på Wine-Searcher
+                      </a>
+                    )}
+                  </div>
+                )}
+                {product.usage && <p className="card__usage">Passar till: {product.usage}</p>}
+              </li>
+            );
+          })}
         </ul>
       </section>
     </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -405,6 +405,54 @@
   text-decoration: underline;
 }
 
+.card__analysis-firecrawl {
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  background: rgba(37, 99, 235, 0.05);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card__analysis-firecrawl h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.card__analysis-firecrawl-summary {
+  margin: 0;
+  color: #1f2937;
+  line-height: 1.5;
+}
+
+.card__analysis-firecrawl-status {
+  margin: 0;
+  color: #1d4ed8;
+  font-style: italic;
+}
+
+.card__analysis-firecrawl-note {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.card__analysis-firecrawl-note code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.card__analysis-firecrawl-error {
+  margin: 0;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
 .badge--value {
   background: #e0e7ff;
   color: #312e81;

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -1,0 +1,302 @@
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.page__header h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0;
+}
+
+.page__header p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.filters {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.filters__row {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .filters__row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.filters__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filters__group label {
+  font-weight: 600;
+  color: #111827;
+}
+
+.filters__group input,
+.filters__group select {
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: #f9fafb;
+}
+
+.filters__group input:focus,
+.filters__group select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  background: #ffffff;
+}
+
+.filters__group--inline label {
+  display: block;
+}
+
+.filters__inputs-inline {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filters__separator {
+  text-align: center;
+  color: #9ca3af;
+}
+
+.filters__checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 4px;
+  border: 1px solid #9ca3af;
+}
+
+.filters__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .filters__footer {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.filters__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: #1f2937;
+}
+
+.filter-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+}
+
+.filter-tag:hover {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.button {
+  font-weight: 600;
+  padding: 0.65rem 1.1rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.button--ghost {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.button--ghost:hover:enabled {
+  background: #d1d5db;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.results__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+@media (min-width: 720px) {
+  .results__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.results__header h2 {
+  margin: 0;
+}
+
+.results__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.results__average {
+  background: #e0f2fe;
+  color: #0369a1;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+}
+
+.results__error {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid rgba(185, 28, 28, 0.35);
+}
+
+.results__empty {
+  margin: 0;
+  color: #6b7280;
+}
+
+.results__grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.04);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.card__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card__price {
+  font-weight: 700;
+  color: #047857;
+}
+
+.card__details {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card__details dt {
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.card__details dd {
+  margin: 0;
+  color: #1f2937;
+}
+
+.card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  background: #dcfce7;
+  color: #166534;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.card__description {
+  margin: 0;
+  color: #374151;
+}
+
+.card__usage {
+  margin: 0;
+  color: #1d4ed8;
+  font-weight: 500;
+}

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -221,6 +221,61 @@
   color: #6b7280;
 }
 
+.results__insights {
+  background: #f8fafc;
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.results__insights h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1d4ed8;
+}
+
+.results__insights-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.results__insights-stats div {
+  background: #eff6ff;
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.results__insights-stats dt {
+  margin: 0;
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+.results__insights-stats dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.results__insights-leaders {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.results__insights-leaders li {
+  list-style: disc;
+}
+
 .results__grid {
   list-style: none;
   display: grid;
@@ -293,6 +348,86 @@
 .card__description {
   margin: 0;
   color: #374151;
+}
+
+.card__analysis {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card__analysis-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.card__analysis-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.card__analysis dl {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card__analysis dt {
+  font-weight: 600;
+  color: #334155;
+}
+
+.card__analysis dd {
+  margin: 0;
+  color: #0f172a;
+}
+
+.card__analysis-note {
+  margin: 0;
+  color: #4b5563;
+  font-style: italic;
+}
+
+.card__analysis-link {
+  align-self: flex-start;
+  text-decoration: none;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.card__analysis-link:hover {
+  text-decoration: underline;
+}
+
+.badge--value {
+  background: #e0e7ff;
+  color: #312e81;
+}
+
+.badge--value-exceptionell {
+  background: #f5f3ff;
+  color: #5b21b6;
+}
+
+.badge--value-stark {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge--value-neutral {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.badge--value-svag {
+  background: #fee2e2;
+  color: #991b1b;
 }
 
 .card__usage {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,28 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #111827;
+  background-color: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f3f4f6;
+}
+
+a {
+  color: inherit;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "allowSyntheticDefaultImports": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true
+  }
+});


### PR DESCRIPTION
## Summary
- set up a Vite + React frontend scaffold for browsing wine data and added fallback sample products
- implement wine search UI with category, price, alcohol, and sustainability filters plus sorting and stats
- document how to run the app alongside the Systembolaget data service and ignore transient build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d62db302e88331a729b086c49d8bf2